### PR TITLE
Fix typo in marker for abstract classes

### DIFF
--- a/src/ClassDiagramRenderer/Node/AbstractClass_.php
+++ b/src/ClassDiagramRenderer/Node/AbstractClass_.php
@@ -9,7 +9,7 @@ class AbstractClass_ extends Node
     {
         return <<<EOM
             class $this->name {
-                    <<abstruct>>
+                    <<abstract>>
                 }
             EOM;
     }


### PR DESCRIPTION
There is "obstruction" and there is "abstract", but there is no "abstruct".