### PR TITLE
fix: Exclude 'self' from dependency node names and add static factory method

### DIFF
--- a/src/ClassDiagramRenderer/Node/Connector/DependencyConnector.php
+++ b/src/ClassDiagramRenderer/Node/Connector/DependencyConnector.php
@@ -45,9 +45,7 @@ class DependencyConnector extends Connector
             if ($method->returnType instanceof Name) {
                 $parts                 = $method->returnType->getParts();
                 $returnTypeName = end($parts);
-                if ($returnTypeName !== 'self') {
-                    $dependencyNodeNames[] = $returnTypeName;
-                }
+                $dependencyNodeNames[] = $returnTypeName;
             }
         }
 
@@ -61,7 +59,7 @@ class DependencyConnector extends Connector
         }
 
         // remove duplicates
-        $dependencyNodeNames = array_unique($dependencyNodeNames);
+        $dependencyNodeNames = array_filter(array_unique($dependencyNodeNames), fn($name) => $name !== 'self');
 
         return new DependencyConnector($classDiagramNode->nodeName(), $dependencyNodeNames);
     }

--- a/tests/ClassDiagram/data/SomeClassA.php
+++ b/tests/ClassDiagram/data/SomeClassA.php
@@ -10,4 +10,9 @@ class SomeClassA extends SomeAbstractClass
     public function __construct(private SomeClassC $someClassC, SomeClassD $someClassD, private int $int)
     {
     }
+
+    public static function getInstance(): self
+    {
+        return new self(new SomeClassC(), new SomeClassD(), 1);
+    }
 }


### PR DESCRIPTION
### Summary

This PR modifies the `DependencyConnector` class to exclude `self` from dependency node names. Additionally, a static factory method `getInstance` is added to the `SomeClassA` class.

### Changes

1. Updated the `parse` method in the `DependencyConnector` class to exclude `self` from dependency node names.
2. Added a static factory method `getInstance` to `tests/ClassDiagram/data/SomeClassA.php`.

### Reason for Changes

- The `self` type is not appropriate as a dependency node name and should be excluded.
- The static factory method simplifies the instantiation of `SomeClassA`.