### PR TITLE
feat(cli): Add --exclude-relationships and relationship filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Repository Guidelines
+
+## Project Structure and Modules
+- Source: `src/` (PSR-4 `Tasuku43\MermaidClassDiagram\...`). See `ARCHITECTURE.md` for architecture and module details.
+- CLI: `mermaid-class-diagram` (also runnable via `vendor/bin/mermaid-class-diagram`).
+- Meta files: `composer.json` (autoload/deps), `composer.lock`, `vendor/`.
+
+## Build, Test, and Development
+- Install deps: `composer install`
+- Run tests:
+  - `vendor/bin/phpunit -c tests/phpunit.xml.dist`
+  - or `vendor/bin/phpunit tests`
+- Try the CLI:
+  - Directory: `vendor/bin/mermaid-class-diagram generate --path src`
+  - Single file: `vendor/bin/mermaid-class-diagram generate --path src/SomeClassA.php`
+
+## Coding Standards and Naming
+- Standard: PSR-12, 4-space indentation. Prefer strict types, typed returns/properties where possible.
+- Naming: Classes in StudlyCaps; methods/properties in camelCase. Namespace `Tasuku43\MermaidClassDiagram\...`.
+- Autoloading (PSR-4): Configure via Composer `autoload.psr-4`. This repo maps `Tasuku43\MermaidClassDiagram\` to `src/`, so `Tasuku43\MermaidClassDiagram\Foo\Bar` resides at `src/Foo/Bar.php`.
+- Organization: Place Console commands under `Console/Command`; keep options consistent (e.g., `--path`).
+- Design: Keep the public API minimal; renderer small and functionally oriented.
+
+## Testing Guidelines
+- Framework: PHPUnit 9.5.
+- Layout: Place `*Test.php` in `tests/`, mirroring `src/` structure when practical.
+- Execution: `vendor/bin/phpunit -c tests/phpunit.xml.dist`.
+- Targets: Node analysis; detection of relationships (inheritance/realization/dependency/composition); verification of Mermaid output lines.
+- Fixtures: Use `tests/data/` for sample inputs.
+
+## Commit and PR Guidelines
+- Commits: Prefer Conventional Commits (e.g., `feat:`, `fix:`, `refactor:`, `test:`, `build(deps):`).
+- PRs should include:
+  - Purpose/context with related issue links.
+  - Scope of changes and whether there are breaking changes.
+  - CLI output and Mermaid before/after when relevant.
+
+## Security and Configuration Tips
+- No runtime secrets required. Never execute the target PHP; static analysis only.
+- Validate `--path` input and avoid side effects during analysis.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,137 @@
+# Architecture Overview (php-mermaid-class-diagram)
+
+## Goals and Principles
+- Purpose: Generate Mermaid class diagrams (classDiagram) from PHP source code.
+- Focus: Omit class internals as much as possible and accurately extract only “nodes (types)” and “relationships (inheritance, realization, composition, dependency)”.
+- Design: Small responsibilities, clear separation between parsing and rendering, and a preference for pure transformations.
+
+## Directory Layout and Separation of Concerns
+- `src/`
+  - `ClassDiagramRenderer/`
+    - Holds models for nodes and relationships, AST-based analysis (Connector classes), and rendering logic.
+    - Key classes:
+      - `ClassDiagram`: Aggregates nodes and relationships; renders Mermaid text.
+      - `ClassDiagramBuilder`: Facade to parse and assemble nodes/relationships.
+      - `Node/*`: Type representations (`Class_`, `AbstractClass_`, `Interface_`, `Enum_`) and the common abstract `Node`, plus the `Nodes` collection.
+      - `Node/Relationship/*`: Relationship representations (`Inheritance`, `Realization`, `Composition`, `Dependency`).
+      - `Node/Connector/*`: Extract relationship information from the AST and connect `Node`s on `Nodes`.
+      - `Node/NodeParser`: Uses Finder to collect files, PHP-Parser to build AST, and Connectors to extract relationships.
+  - `Console/Command/GenerateCommand.php`: Symfony Console command (`generate --path`).
+- `mermaid-class-diagram`: Executable binary that boots the Console app.
+- `tests/`: PHPUnit tests and fixtures (`tests/data/Project/*`).
+
+## Domain Model
+### Nodes (types)
+- `Node` (abstract)
+  - Minimal representation of a type with `$name`.
+  - Holds source collections for relationships:
+    - `$extends`, `$implements`, `$properties` (composition), `$depends` (dependency)
+  - `relationships()`: Builds an array of `Relationship` objects from the above collections.
+    - De-duplicates and filters: removes conflicts (e.g., dependency also present as composition/inheritance/realization) and self references.
+  - `sortNodes(array &$nodes)`: Sorts by node name (ascending).
+- Concrete types
+  - `Class_`, `AbstractClass_`, `Interface_`, `Enum_`
+  - `render()`: Outputs Mermaid `class` syntax; stereotypes `<<abstract>>`, `<<interface>>`, `<<enum>>` when applicable.
+- `Nodes`
+  - Dictionary-like collection keyed by node name.
+  - Provides `add()`, `findByName()`, `getAllNodes()`.
+
+### Relationships
+- `Relationship` (abstract): Holds `from` and `to`; `render()` outputs Mermaid edges.
+  - `sortRelationships(array &$relationships)`: Sorts by `from to` (ascending).
+- Concrete relationships and Mermaid syntax
+  - `Inheritance`: `Parent <|-- Child: inheritance`
+  - `Realization`: `Interface <|.. Class: realization`
+  - `Composition`: `Owner *-- Part: composition`
+  - `Dependency`: `From ..> To: dependency`
+
+## Analysis Pipeline (AST → Nodes/Relationships)
+- Entry point: `ClassDiagramBuilder::build(string $path)`
+  1) Call `NodeParser::parse($path)` to get `Nodes`.
+  2) For each `Node`, collect `relationships()` into `ClassDiagram`.
+- `NodeParser`
+  - Input: `--path` may be a directory (glob `*.php`) or a single file (`Symfony\Component\Finder\Finder`).
+  - Preparation: Build AST with `PhpParser`; run `NameResolver` and `ParentConnectingVisitor`.
+  - Class-like detection:
+    - Gather `Stmt\ClassLike` (Class/Interface/Enum) and also `Stmt\Trait_` nodes, but only Class/Interface/Enum become `Node`s.
+    - If no valid class-like found in a file, skip via `CannnotParseToClassLikeException`.
+  - Two-phase processing:
+    - Phase 1: Create `Node` (`Class_`/`AbstractClass_`/`Interface_`/`Enum_`) for each valid class-like and add to `Nodes`.
+    - Phase 2: Build Connector instances, then call `connect()` to wire up relationships.
+- Connectors (AST → edges on `Nodes`)
+  - `InheritanceConnector`
+    - Extracts `extends` (Interface→Interface, otherwise Class→Class).
+    - Missing referenced types are synthesized (`Interface_` or `Class_`).
+  - `RealizationConnector`
+    - Extracts `implements`; synthesizes missing interfaces as `Interface_`.
+  - `CompositionConnector`
+    - Treats constructor property promotion params with visibility and type `Name` as composition.
+    - Treats properties whose type is `FullyQualified` as composition.
+  - `DependencyConnector`
+    - Method params typed as `Name` with flags===0 (non-promotion) are dependencies.
+    - Method return types of `Name` are dependencies.
+    - `new` expressions (`Expr\New_`) add dependencies.
+    - Filters out `self` and de-duplicates.
+
+## Rendering
+- `ClassDiagram::render()`
+  - Sorts nodes by name; sorts relationships by `from to`.
+  - Emits nodes first, then a blank line, then relationships.
+  - Header line `classDiagram`; each subsequent line is indented by 4 spaces.
+- Examples
+  - Nodes: `class UserService {}` / Interface: `class UserRepositoryInterface { <<interface>> }`
+  - Edges: `UserService *-- UserRepositoryInterface: composition`, `UserService ..> User: dependency`
+
+## CLI
+- Entry: `mermaid-class-diagram`
+  - Boots `Symfony\Component\Console\Application` and registers `GenerateCommand`.
+- Command: `generate`
+  - Option: `--path` (required; file or directory).
+  - Execution: `GenerateCommand::execute()` delegates to `ClassDiagramBuilder`, then writes the Mermaid text to stdout.
+  - AST: `ParserFactory::createForVersion(PhpVersion::fromComponents(8, 1))` (PHP 8.1).
+
+## Dependencies
+- Runtime
+  - `nikic/php-parser` (^4.14 || ^5.0): AST building and traversal.
+  - `symfony/finder` (^7.0): File discovery.
+  - `symfony/console` (^7.0): CLI framework.
+- Dev
+  - `phpunit/phpunit` (^9.5): Unit tests.
+
+## Notes and Trade-offs
+- Type resolution simplifications
+  - Composition (properties) only considers `FullyQualified` types; non-FQCN and union types are out of scope for now.
+  - Dependencies consider `Name` types; `self` is ignored.
+- Synthesizing missing references
+  - Types referenced but not defined in the scan scope are synthesized as minimal `Node`s so relationships still render.
+  - This may produce nodes in the output with empty bodies.
+- Traits
+  - Traits are detected in AST collection but not rendered as nodes; only Class/Interface/Enum are supported.
+- Safety
+  - Never executes target PHP; analysis is static and AST-based.
+  - CLI does not currently validate `--path` beyond being required.
+
+## Testing Strategy
+- Unit tests
+  - Validate node rendering/sorting and relationship extraction (inheritance/realization/composition/dependency).
+  - Compare `ClassDiagram`/`ClassDiagramBuilder` output against precise expected strings.
+- Fixtures
+  - `tests/data/Project/*` provides a small pseudo-app to cover common patterns.
+
+## Extensibility
+- New relationships
+  - Add a `Relationship` subclass and corresponding Connector `parse()/connect()`; register it in `NodeParser::$connectorParsers`.
+- New node kinds
+  - Add a `Node` subclass and extend `NodeParser::createClassDiagramNodeFromClassLike()`.
+- Extraction rules
+  - Adjust AST predicates in `CompositionConnector`/`DependencyConnector` to widen/narrow detection.
+
+## Flow Summary
+1) Discover PHP files with Finder.
+2) Build and normalize AST with PHP-Parser.
+3) Register Class/Interface/Enum nodes in `Nodes`.
+4) Connectors extract relationships from AST and wire nodes in `Nodes`.
+5) `ClassDiagramBuilder` aggregates and `ClassDiagram::render()` prints Mermaid.
+
+---
+This document exists to make future changes faster by clarifying where responsibilities live and how to extend the system safely.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,11 +82,19 @@
   - Nodes: `class UserService {}` / Interface: `class UserRepositoryInterface { <<interface>> }`
   - Edges: `UserService *-- UserRepositoryInterface: composition`, `UserService ..> User: dependency`
 
+### Render options
+- `RenderOptions` controls view-time filtering without changing parsing (all default true via `RenderOptions::default()`):
+  - `includeDependencies`: show/hide `Dependency` edges (parameter/return/`new`-derived)
+  - `includeCompositions`: show/hide `Composition` edges (properties/constructor promotion/FQCN properties)
+  - `includeInheritances`: show/hide `Inheritance` edges (`extends`)
+  - `includeRealizations`: show/hide `Realization` edges (`implements`)
+
 ## CLI
 - Entry: `mermaid-class-diagram`
   - Boots `Symfony\Component\Console\Application` and registers `GenerateCommand`.
 - Command: `generate`
   - Option: `--path` (required; file or directory).
+  - Option: `--exclude-relationships` (CSV): exclude relationship types: `dependency,composition,inheritance,realization` (aliases supported)
   - Execution: `GenerateCommand::execute()` delegates to `ClassDiagramBuilder`, then writes the Mermaid text to stdout.
   - AST: `ParserFactory::createForVersion(PhpVersion::fromComponents(8, 1))` (PHP 8.1).
 

--- a/README.md
+++ b/README.md
@@ -149,5 +149,23 @@ classDiagram
     SomeClassD <.. SomeClassA: dependency
 ```
 
+### Filter relationships
+You can hide specific relationship types via CSV with `--exclude-relationships`.
+
+- Allowed values (case-insensitive, aliases supported):
+  - `dependency` | `dependencies` | `dep` | `deps`
+  - `composition` | `compositions` | `comp`
+  - `inheritance` | `inheritances` | `extends`
+  - `realization` | `realizations` | `implements`
+
+Examples
+```shell
+# Hide dependencies and compositions
+$ vendor/bin/mermaid-class-diagram generate --path src --exclude-relationships dependency,composition
+
+# Hide only dependencies
+$ vendor/bin/mermaid-class-diagram generate --path src --exclude-relationships dependency
+```
+
 ## License
 The MIT License (MIT). Please see [LICENSE](https://github.com/tasuku43/php-mermaid-class-diagram/blob/main/LICENSE) for more information.

--- a/src/ClassDiagramRenderer/ClassDiagram.php
+++ b/src/ClassDiagramRenderer/ClassDiagram.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 namespace Tasuku43\MermaidClassDiagram\ClassDiagramRenderer;
 
 use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\Node;
+use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\Relationship\Dependency;
+use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\Relationship\Composition;
+use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\Relationship\Inheritance;
+use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\Relationship\Realization;
 use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\Relationship\Relationship;
+use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\Relationship\Relationships;
 
 class ClassDiagram
 {
@@ -13,10 +18,13 @@ class ClassDiagram
      */
     private array $nodes;
 
-    /**
-     * @var Relationship[]
-     */
-    private array $relationships = [];
+    private Relationships $relationships;
+
+    public function __construct()
+    {
+        $this->nodes = [];
+        $this->relationships = Relationships::empty();
+    }
 
     public function addNode(Node $node): self
     {
@@ -27,15 +35,17 @@ class ClassDiagram
 
     public function addRelationships(Relationship ...$relationships): self
     {
-        $this->relationships = [...$this->relationships, ...$relationships];
+        foreach ($relationships as $relationship) {
+            $this->relationships->add($relationship);
+        }
 
         return $this;
     }
 
-    public function render(): string
+    public function render(RenderOptions $options = null): string
     {
         Node::sortNodes($this->nodes);
-        Relationship::sortRelationships($this->relationships);
+        $this->relationships->sort();
 
         $output = "classDiagram\n";
 
@@ -45,7 +55,7 @@ class ClassDiagram
 
         $output .= "\n";
 
-        foreach ($this->relationships as $relationship) {
+        foreach ($this->relationships->filter($options)->getAll() as $relationship) {
             $output .= "    " . $relationship->render() . "\n";
         }
 

--- a/src/ClassDiagramRenderer/Node/Relationship/Relationships.php
+++ b/src/ClassDiagramRenderer/Node/Relationship/Relationships.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\Relationship;
+
+use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\RenderOptions;
+
+class Relationships
+{
+    /**
+     * @param Relationship[] $relationships
+     */
+    private function __construct(private array $relationships)
+    {
+    }
+
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+
+    public function add(Relationship $relationship): void
+    {
+        $this->relationships[] = $relationship;
+    }
+
+    /**
+     * @return Relationship[]
+     */
+    public function getAll(): array
+    {
+        return $this->relationships;
+    }
+
+    public function sort(): void
+    {
+        Relationship::sortRelationships($this->relationships);
+    }
+
+    public function filter(RenderOptions $options): self
+    {
+        $filtered = array_filter($this->relationships, function (Relationship $relationship) use ($options) {
+            if ($relationship instanceof Dependency && !$options->includeDependencies) {
+                return false;
+            }
+            if ($relationship instanceof Composition && !$options->includeCompositions) {
+                return false;
+            }
+            if ($relationship instanceof Inheritance && !$options->includeInheritances) {
+                return false;
+            }
+            if ($relationship instanceof Realization && !$options->includeRealizations) {
+                return false;
+            }
+
+            return true;
+        });
+
+        return new self(array_values($filtered));
+    }
+}
+

--- a/src/ClassDiagramRenderer/RenderOptions.php
+++ b/src/ClassDiagramRenderer/RenderOptions.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Tasuku43\MermaidClassDiagram\ClassDiagramRenderer;
+
+class RenderOptions
+{
+    public function __construct(
+        public bool $includeDependencies,
+        public bool $includeCompositions,
+        public bool $includeInheritances,
+        public bool $includeRealizations,
+    ) {
+    }
+
+    public static function default(): self
+    {
+        return new self(true, true, true, true);
+    }
+}

--- a/tests/ClassDiagramRenderer/ClassDiagramBuilderTest.php
+++ b/tests/ClassDiagramRenderer/ClassDiagramBuilderTest.php
@@ -9,6 +9,7 @@ use PhpParser\ParserFactory;
 use PhpParser\PhpVersion;
 use PHPUnit\Framework\TestCase;
 use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\ClassDiagramBuilder;
+use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\RenderOptions;
 use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\NodeParser;
 
 class ClassDiagramBuilderTest extends TestCase
@@ -84,6 +85,45 @@ classDiagram
 
     AbstractController <|-- UserController: inheritance
     UserController *-- UserService: composition
+
+EOT;
+
+        $this->assertSame($expectedDiagram, $classDiagram);
+    }
+
+    public function testBuildFromSampleProjectOnlyPropertiesDeps(): void
+    {
+        $path = __DIR__ . '/../data/Project';
+
+        $classDiagram = $this->classDigagramBuilder
+            ->build($path)
+            ->render(new RenderOptions(false, true, true, true));
+
+        $expectedDiagram = <<<'EOT'
+classDiagram
+    class AbstractController {
+        <<abstract>>
+    }
+    class User {
+    }
+    class UserController {
+    }
+    class UserRepository {
+    }
+    class UserRepositoryInterface {
+        <<interface>>
+    }
+    class UserService {
+    }
+    class UserStatus {
+        <<enum>>
+    }
+
+    User *-- UserStatus: composition
+    AbstractController <|-- UserController: inheritance
+    UserController *-- UserService: composition
+    UserRepositoryInterface <|.. UserRepository: realization
+    UserService *-- UserRepositoryInterface: composition
 
 EOT;
 

--- a/tests/ClassDiagramRenderer/ClassDiagramBuilderTest.php
+++ b/tests/ClassDiagramRenderer/ClassDiagramBuilderTest.php
@@ -33,7 +33,7 @@ class ClassDiagramBuilderTest extends TestCase
         
         $classDiagram = $this->classDigagramBuilder
             ->build($path)
-            ->render();
+            ->render(RenderOptions::default());
 
         $expectedDiagram = <<<'EOT'
 classDiagram
@@ -76,7 +76,7 @@ EOT;
 
         $classDiagram = $this->classDigagramBuilder
             ->build($path)
-            ->render();
+            ->render(RenderOptions::default());
 
         $expectedDiagram = <<<'EOT'
 classDiagram

--- a/tests/ClassDiagramRenderer/ClassDiagramTest.php
+++ b/tests/ClassDiagramRenderer/ClassDiagramTest.php
@@ -5,6 +5,7 @@ namespace Tasuku43\Tests\MermaidClassDiagram\ClassDiagramRenderer;
 
 use PHPUnit\Framework\TestCase;
 use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\ClassDiagram;
+use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\RenderOptions;
 use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\Class_;
 use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\Interface_;
 use Tasuku43\MermaidClassDiagram\ClassDiagramRenderer\Node\Relationship\Inheritance;
@@ -26,7 +27,7 @@ class ClassDiagramTest extends TestCase
         $this->assertSame($diagram, $resultDiagram);
         
         // Verify the node is included in the rendered output
-        $rendered = $diagram->render();
+        $rendered = $diagram->render(RenderOptions::default());
         $expectedOutput = <<<'EOT'
 classDiagram
     class TestClass {
@@ -57,7 +58,7 @@ EOT;
         $diagram->addNode($class1)->addNode($class2);
         
         // Verify the relationship is included in the rendered output
-        $rendered = $diagram->render();
+        $rendered = $diagram->render(RenderOptions::default());
         $expectedOutput = <<<'EOT'
 classDiagram
     class Class1 {
@@ -86,7 +87,7 @@ EOT;
                 ->addNode($interface)
                 ->addRelationships($relationship);
         
-        $rendered = $diagram->render();
+        $rendered = $diagram->render(RenderOptions::default());
         $expectedOutput = <<<'EOT'
 classDiagram
     class TestClass {


### PR DESCRIPTION
This PR introduces relationship-level filtering and a clearer CLI for excluding edges at render time.

Closes #27

Summary
- Add `--exclude-relationships` (CSV) to the CLI to hide specific relationship types: dependency, composition, inheritance, realization. Aliases supported (dep/comp/extends/implements).
- Introduce `Relationships` collection to encapsulate relationship storage, sorting, and filtering.
- Expand `RenderOptions` with explicit required flags and a `RenderOptions::default()` factory.
- Wire filtering in `ClassDiagram::render()` via `Relationships::filter(RenderOptions)`.
- Update README and ARCHITECTURE to document the new option and flags.
- Remove legacy flag `--only-properties-deps` and previous `--exclude` (no compatibility kept as requested).

Why
- Make filtering behavior explicit and composable by relationship type.
- Clarify CLI semantics by naming the target domain (relationships).

Details
- Public API: `RenderOptions` now requires 4 boolean args; use `RenderOptions::default()` for defaults.
- Renderer: `ClassDiagram` now holds `Relationships` instead of an array.
- Behavior: Defaults remain unchanged; your output stays the same unless you pass an exclude list.

Examples
- Hide dependencies and compositions:
  `vendor/bin/mermaid-class-diagram generate --path src --exclude-relationships dependency,composition`
- Hide only dependencies:
  `vendor/bin/mermaid-class-diagram generate --path src --exclude-relationships dependency`

Testing
- PHPUnit: all tests pass locally (37 tests, 64 assertions).

Notes
- Future room: add complementary `--include-relationships` if desired for explicit whitelisting.
